### PR TITLE
Create player 오류 수정

### DIFF
--- a/src/components/Youtube/index.tsx
+++ b/src/components/Youtube/index.tsx
@@ -125,7 +125,7 @@ class Youtube extends Component<Props> {
       width = '100',
       height = '100',
       autoplay,
-      customProps: { videoId },
+      customProps: { videoId = '' },
     } = this.props;
 
     try {
@@ -145,7 +145,7 @@ class Youtube extends Component<Props> {
         },
       });
     } catch (err) {
-      console.log('Cannot create Player.');
+      console.log('Cannot create Player.', err);
     }
   }
 


### PR DESCRIPTION
- player 생성 시, videoId 타입이 string이 아니여서 생성에 실패하는 케이스 수정